### PR TITLE
Update references to tool_lifecycle classes to work with local\ namespaces

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -26,8 +26,8 @@
 
 namespace tool_lifecycle\step;
 
-use tool_lifecycle\manager\settings_manager;
-use tool_lifecycle\response\step_response;
+use tool_lifecycle\local\manager\settings_manager;
+use tool_lifecycle\local\response\step_response;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/version.php
+++ b/version.php
@@ -25,5 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2019030701;
+$plugin->version  = 2019102900;
 $plugin->component = 'lifecyclestep_movecategory';
+$plugin->dependencies = array(
+        'tool_lifecycle' => 2019102900
+);


### PR DESCRIPTION
Because of learnweb/moodle-tool_lifecycle#87, most of the classes of tool_lifecycle needed to be moved.

This PR corrects the namespaces used in lifecyclestep_movecategory in order to work with the refactored version of tool_lifecycle. It should be merged once learnweb/moodle-tool_lifecycle#95 is merged, but not before.

We will add a comment here when we merged learnweb/moodle-tool_lifecycle#95.