### PR TITLE
Require moodle course lib in funtion process_course(...) in lib.php to prevent error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -33,6 +33,9 @@ use tool_lifecycle\settings_type;
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../lib.php');
+// Add moodle course lib
+global $CFG;
+require_once($CFG->dirroot . '/course/lib.php');
 
 class movecategory extends libbase {
 


### PR DESCRIPTION
Require moodle course lib in funtion process_course(...) in lib.php to prevent error: Scheduled task failed: Run the life cycle processes (tool_lifecycle\task\lifecycle_task), Call to undefined function tool_lifecycle\step\move_courses()

![Require moodle course lib in function process_course to prevent error](https://github.com/user-attachments/assets/754ebe00-f24f-4902-9555-565e2851a37a)
